### PR TITLE
fix(p0): re-enable React.StrictMode and remove duplicate LanguageProvider

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { LanguageProvider } from './context/LanguageContext';
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  // <React.StrictMode>
-    <LanguageProvider>
-      <App />
-    </LanguageProvider>
-  // </React.StrictMode>
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
 );


### PR DESCRIPTION
## Summary

- Re-enables `React.StrictMode` in `main.tsx` which was commented out, preventing detection of side-effect bugs and deprecated API usage
- Removes the duplicate `LanguageProvider` wrapper in `main.tsx` (it already exists in `App.tsx`), which was causing the context to be initialized twice

## Test plan

- [x] App boots without console errors
- [x] In development, React.StrictMode double-invokes effects — verify no broken behaviour surfaces
- [x] Language switching still works correctly (single LanguageProvider in App.tsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)