### PR TITLE
refactor(p2): deduplicate createEmployee/createManager/createHrAdmin in employeeApi

### DIFF
--- a/src/api/employeeApi.ts
+++ b/src/api/employeeApi.ts
@@ -279,6 +279,33 @@ function normalizeEmployee(raw: unknown): BackendEmployee {
 class EmployeeApiService {
   private baseUrl = '/employees';
 
+  private buildFormData(employeeData: EmployeeDto): FormData {
+    const formData = new FormData();
+    formData.append('first_name', employeeData.first_name);
+    formData.append('last_name', employeeData.last_name);
+    formData.append('email', employeeData.email);
+    formData.append('phone', employeeData.phone);
+    if (employeeData.password) formData.append('password', employeeData.password);
+    formData.append('designation_id', employeeData.designationId);
+    formData.append('gender', employeeData.gender);
+    if (employeeData.role_name) formData.append('role_name', employeeData.role_name);
+    if (employeeData.role_id) formData.append('role_id', employeeData.role_id);
+    if (employeeData.team_id) formData.append('team_id', employeeData.team_id);
+    if (employeeData.cnicNumber) formData.append('cnic_number', employeeData.cnicNumber);
+    if (employeeData.profilePicture)
+      formData.append('profile_picture', employeeData.profilePicture, employeeData.profilePicture.name);
+    if (employeeData.cnicFrontPicture)
+      formData.append('cnic_picture', employeeData.cnicFrontPicture, employeeData.cnicFrontPicture.name);
+    if (employeeData.cnicBackPicture)
+      formData.append('cnic_back_picture', employeeData.cnicBackPicture, employeeData.cnicBackPicture.name);
+    return formData;
+  }
+
+  private async createByEndpoint(endpoint: string, employeeData: EmployeeDto): Promise<BackendEmployee> {
+    const response = await axiosInstance.post<RawEmployee>(endpoint, this.buildFormData(employeeData));
+    return normalizeEmployee(response.data);
+  }
+
   async getAllEmployees(
     filters: EmployeeFilters = {},
     page: number | null = 1
@@ -368,191 +395,15 @@ class EmployeeApiService {
     // NOTE: We intentionally do NOT wrap/transform errors here.
     // The caller (UI) needs access to `error.response.data` for special flows
     // like `requiresPayment` + `checkoutUrl` returned by the backend.
-
-    // Create FormData for multipart/form-data submission
-    const formData = new FormData();
-
-    // Add text fields
-    formData.append('first_name', employeeData.first_name);
-    formData.append('last_name', employeeData.last_name);
-    formData.append('email', employeeData.email);
-    formData.append('phone', employeeData.phone);
-    if (employeeData.password) {
-      formData.append('password', employeeData.password);
-    }
-    formData.append('designation_id', employeeData.designationId);
-    formData.append('gender', employeeData.gender);
-    if (employeeData.role_name) {
-      formData.append('role_name', employeeData.role_name);
-    }
-    if (employeeData.role_id) {
-      formData.append('role_id', employeeData.role_id);
-    }
-    if (employeeData.team_id) {
-      formData.append('team_id', employeeData.team_id);
-    }
-    if (employeeData.cnicNumber) {
-      formData.append('cnic_number', employeeData.cnicNumber);
-    }
-
-    // Add image files if they exist
-    if (employeeData.profilePicture) {
-      formData.append(
-        'profile_picture',
-        employeeData.profilePicture,
-        employeeData.profilePicture.name
-      );
-    }
-    if (employeeData.cnicFrontPicture) {
-      formData.append(
-        'cnic_picture',
-        employeeData.cnicFrontPicture,
-        employeeData.cnicFrontPicture.name
-      );
-    }
-    if (employeeData.cnicBackPicture) {
-      formData.append(
-        'cnic_back_picture',
-        employeeData.cnicBackPicture,
-        employeeData.cnicBackPicture.name
-      );
-    }
-
-    const response = await axiosInstance.post<RawEmployee>(
-      this.baseUrl,
-      formData,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      }
-    );
-    return normalizeEmployee(response.data);
+    return this.createByEndpoint(this.baseUrl, employeeData);
   }
 
   async createManager(employeeData: EmployeeDto): Promise<BackendEmployee> {
-    // Create FormData for multipart/form-data submission
-    const formData = new FormData();
-
-    // Add text fields
-    formData.append('first_name', employeeData.first_name);
-    formData.append('last_name', employeeData.last_name);
-    formData.append('email', employeeData.email);
-    formData.append('phone', employeeData.phone);
-    if (employeeData.password) {
-      formData.append('password', employeeData.password);
-    }
-    formData.append('designation_id', employeeData.designationId);
-    formData.append('gender', employeeData.gender);
-    if (employeeData.role_name) {
-      formData.append('role_name', employeeData.role_name);
-    }
-    if (employeeData.role_id) {
-      formData.append('role_id', employeeData.role_id);
-    }
-    if (employeeData.team_id) {
-      formData.append('team_id', employeeData.team_id);
-    }
-    if (employeeData.cnicNumber) {
-      formData.append('cnic_number', employeeData.cnicNumber);
-    }
-
-    // Add image files if they exist
-    if (employeeData.profilePicture) {
-      formData.append(
-        'profile_picture',
-        employeeData.profilePicture,
-        employeeData.profilePicture.name
-      );
-    }
-    if (employeeData.cnicFrontPicture) {
-      formData.append(
-        'cnic_picture',
-        employeeData.cnicFrontPicture,
-        employeeData.cnicFrontPicture.name
-      );
-    }
-    if (employeeData.cnicBackPicture) {
-      formData.append(
-        'cnic_back_picture',
-        employeeData.cnicBackPicture,
-        employeeData.cnicBackPicture.name
-      );
-    }
-
-    const response = await axiosInstance.post<RawEmployee>(
-      `${this.baseUrl}/manager`,
-      formData,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      }
-    );
-    return normalizeEmployee(response.data);
+    return this.createByEndpoint(`${this.baseUrl}/manager`, employeeData);
   }
 
-  // Create a new HR admin employee
   async createHrAdmin(employeeData: EmployeeDto): Promise<BackendEmployee> {
-    // Create FormData for multipart/form-data submission
-    const formData = new FormData();
-
-    // Add text fields
-    formData.append('first_name', employeeData.first_name);
-    formData.append('last_name', employeeData.last_name);
-    formData.append('email', employeeData.email);
-    formData.append('phone', employeeData.phone);
-    if (employeeData.password) {
-      formData.append('password', employeeData.password);
-    }
-    formData.append('designation_id', employeeData.designationId);
-    formData.append('gender', employeeData.gender);
-    if (employeeData.role_name) {
-      formData.append('role_name', employeeData.role_name);
-    }
-    if (employeeData.role_id) {
-      formData.append('role_id', employeeData.role_id);
-    }
-    if (employeeData.team_id) {
-      formData.append('team_id', employeeData.team_id);
-    }
-    if (employeeData.cnicNumber) {
-      formData.append('cnic_number', employeeData.cnicNumber);
-    }
-
-    // Add image files if they exist
-    if (employeeData.profilePicture) {
-      formData.append(
-        'profile_picture',
-        employeeData.profilePicture,
-        employeeData.profilePicture.name
-      );
-    }
-    if (employeeData.cnicFrontPicture) {
-      formData.append(
-        'cnic_picture',
-        employeeData.cnicFrontPicture,
-        employeeData.cnicFrontPicture.name
-      );
-    }
-    if (employeeData.cnicBackPicture) {
-      formData.append(
-        'cnic_back_picture',
-        employeeData.cnicBackPicture,
-        employeeData.cnicBackPicture.name
-      );
-    }
-
-    const response = await axiosInstance.post<RawEmployee>(
-      `${this.baseUrl}/hr-admin`,
-      formData,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      }
-    );
-    return normalizeEmployee(response.data);
+    return this.createByEndpoint(`${this.baseUrl}/hr-admin`, employeeData);
   }
 
   async updateEmployee(


### PR DESCRIPTION
## Summary

- Three methods (`createEmployee`, `createManager`, `createHrAdmin`) shared ~70 lines of identical FormData construction logic
- Extracts two private helpers: `buildFormData(employeeData)` and `createByEndpoint(endpoint, employeeData)`
- Each public method is now a single-line delegate, reducing the class by ~140 lines
- Preserves the intentional behaviour that `createEmployee` does **not** wrap errors, so callers can inspect `error.response.data.requiresPayment` for the subscription payment flow

## Test plan

- [ ] Creating a new employee works end-to-end
- [ ] Creating a manager works end-to-end
- [ ] Creating an HR admin works end-to-end
- [ ] Payment-required flow still triggers correctly when employee limit is reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)