### PR TITLE
ci(p3): add type-check, lint, format:check steps and enable noUnusedLocals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,26 +2,34 @@ name: CI
 
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [ main, master, develop, dev ]
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [ main, master, develop, dev ]
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '20'
         cache: 'npm'
-    
+
     - name: Install dependencies
       run: npm ci
-    
+
+    - name: Type check
+      run: npm run type-check
+
+    - name: Lint
+      run: npm run lint
+
+    - name: Format check
+      run: npm run format:check
+
     - name: Build
       run: npm run build
-

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,8 +21,8 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true


### PR DESCRIPTION
## Summary

- Adds separate CI steps for TypeScript type checking, ESLint, and Prettier format verification before the build step — regressions now fail fast with specific error output rather than a cryptic build failure
- Enables `noUnusedLocals: true` and `noUnusedParameters: true` in `tsconfig.app.json` (were explicitly set to `false`; zero violations exist in the codebase so this is a free win)

## Test plan

- [ ] CI pipeline runs all steps on push/PR to main, master, develop, dev
- [ ] `npm run type-check` passes locally
- [ ] `npm run lint` passes locally
- [ ] `npm run format:check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)