### PR TITLE
perf(p4): replace useMemo(JSX) with React.memo components + add smoke tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "preview": "vite preview",
+    "test": "vitest run --project unit",
+    "test:watch": "vitest --project unit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -3,6 +3,7 @@ import {
   useMediaQuery,
   useTheme as useMuiTheme,
   CircularProgress,
+  type Theme,
 } from '@mui/material';
 import React, {
   useEffect,
@@ -24,6 +25,100 @@ import {
   getDefaultDashboardRoute,
   isDashboardPathAllowedForRole,
 } from '../../utils/permissions';
+
+interface SidebarPanelProps {
+  panelRef: React.RefObject<HTMLDivElement | null>;
+  rtlMode: boolean;
+  darkMode: boolean;
+  muiTheme: Theme;
+  closeSidebar: () => void;
+  handleSetDarkMode: React.Dispatch<React.SetStateAction<boolean>>;
+  setRtlMode: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const SidebarPanel = React.memo(function SidebarPanel({
+  panelRef,
+  rtlMode,
+  darkMode,
+  muiTheme,
+  closeSidebar,
+  handleSetDarkMode,
+  setRtlMode,
+}: SidebarPanelProps) {
+  return (
+    <Box
+      ref={panelRef}
+      sx={{
+        backgroundColor: muiTheme.palette.background.paper,
+        color: muiTheme.palette.text.primary,
+        padding: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        direction: rtlMode ? 'rtl' : 'ltr',
+        height: { xs: '100dvh', lg: 'auto' },
+        width: { xs: '240px', lg: '280px' },
+        position: { xs: 'fixed', lg: 'relative' },
+        top: { xs: 0, lg: 'auto' },
+        bottom: { xs: 0, lg: 'auto' },
+        left: rtlMode ? 'auto' : { xs: 0, lg: 'auto' },
+        right: rtlMode ? { xs: 0, lg: 'auto' } : 'auto',
+        mt: { xs: 0, lg: 2.5 },
+        ml: { xs: 0, lg: 2.5 },
+        mb: { xs: 0, lg: 2.5 },
+        borderRadius: { xs: 0, lg: '20px' },
+        zIndex: { xs: 1000, lg: 'auto' },
+      }}
+    >
+      <Sidebar
+        rtlMode={rtlMode}
+        setRtlMode={setRtlMode}
+        darkMode={darkMode}
+        setDarkMode={handleSetDarkMode}
+        onMenuItemClick={closeSidebar}
+      />
+    </Box>
+  );
+});
+
+interface NavbarPanelProps {
+  darkMode: boolean;
+  inviteModalOpen: boolean;
+  toggleSidebar: () => void;
+  handleOpenInviteModal: () => void;
+  handleCloseInviteModal: () => void;
+}
+
+const NavbarPanel = React.memo(function NavbarPanel({
+  darkMode,
+  inviteModalOpen,
+  toggleSidebar,
+  handleOpenInviteModal,
+  handleCloseInviteModal,
+}: NavbarPanelProps) {
+  return (
+    <Box
+      sx={{
+        height: 'auto',
+        display: 'flex',
+        alignItems: 'center',
+        flexShrink: 0,
+        px: { xs: 2, lg: 3 },
+        pt: { xs: 2, lg: 0 },
+      }}
+    >
+      <Navbar
+        onOpenInviteModal={handleOpenInviteModal}
+        onToggleSidebar={toggleSidebar}
+        darkMode={darkMode}
+      />
+      <EmployeeInviteModal
+        open={inviteModalOpen}
+        darkMode={darkMode}
+        onClose={handleCloseInviteModal}
+      />
+    </Box>
+  );
+});
 
 const Layout = () => {
   const muiTheme = useMuiTheme();
@@ -147,87 +242,6 @@ const Layout = () => {
   // Memoize Outlet context to prevent unnecessary re-renders of child components
   const outletContext = useMemo(() => ({ darkMode }), [darkMode]);
 
-  // Memoized Sidebar & Navbar (render once)
-  const MemoizedSidebar = useMemo(
-    () =>
-      sidebarOpen && (
-        <Box
-          ref={sidebarRef}
-          sx={{
-            backgroundColor: muiTheme.palette.background.paper,
-            color: muiTheme.palette.text.primary,
-            padding: 0,
-            display: 'flex',
-            flexDirection: 'column',
-            direction: rtlMode ? 'rtl' : 'ltr',
-            // On mobile, make sidebar truly full-height (avoid fixed/partial height)
-            height: { xs: '100dvh', lg: 'auto' },
-            width: { xs: '240px', lg: '280px' },
-            // Use fixed positioning on mobile so it spans the full viewport height
-            position: { xs: 'fixed', lg: 'relative' },
-            top: { xs: 0, lg: 'auto' },
-            bottom: { xs: 0, lg: 'auto' },
-            left: rtlMode ? 'auto' : { xs: 0, lg: 'auto' },
-            right: rtlMode ? { xs: 0, lg: 'auto' } : 'auto',
-            mt: { xs: 0, lg: 2.5 },
-            ml: { xs: 0, lg: 2.5 },
-            mb: { xs: 0, lg: 2.5 },
-            borderRadius: {
-              // No rounding on mobile so it can fill the full height cleanly
-              xs: 0,
-              lg: '20px',
-            },
-            zIndex: { xs: 1000, lg: 'auto' },
-            // boxShadow:
-            //   muiTheme.palette.mode === 'dark'
-            //     ? '0 1px 3px rgba(0,0,0,0.3)'
-            //     : '0 1px 3px rgba(0,0,0,0.1)',
-          }}
-        >
-          <Sidebar
-            rtlMode={rtlMode}
-            setRtlMode={setRtlMode}
-            darkMode={darkMode}
-            setDarkMode={handleSetDarkMode}
-            onMenuItemClick={closeSidebar}
-          />
-        </Box>
-      ),
-    [sidebarOpen, rtlMode, darkMode, closeSidebar, handleSetDarkMode, muiTheme]
-  );
-
-  const MemoizedNavbar = useMemo(
-    () => (
-      <Box
-        sx={{
-          height: 'auto',
-          display: 'flex',
-          alignItems: 'center',
-          flexShrink: 0,
-          px: { xs: 2, lg: 3 },
-          pt: { xs: 2, lg: 0 },
-        }}
-      >
-        <Navbar
-          onOpenInviteModal={handleOpenInviteModal}
-          onToggleSidebar={toggleSidebar}
-          darkMode={darkMode}
-        />
-        <EmployeeInviteModal
-          open={inviteModalOpen}
-          darkMode={darkMode}
-          onClose={handleCloseInviteModal}
-        />
-      </Box>
-    ),
-    [
-      darkMode,
-      inviteModalOpen,
-      toggleSidebar,
-      handleOpenInviteModal,
-      handleCloseInviteModal,
-    ]
-  );
 
   return (
     <Box
@@ -273,8 +287,17 @@ const Layout = () => {
           />
         )}
 
-        {/* Sidebar (rendered once, static) */}
-        {MemoizedSidebar}
+        {sidebarOpen && (
+          <SidebarPanel
+            panelRef={sidebarRef}
+            rtlMode={rtlMode}
+            darkMode={darkMode}
+            muiTheme={muiTheme}
+            closeSidebar={closeSidebar}
+            handleSetDarkMode={handleSetDarkMode}
+            setRtlMode={setRtlMode}
+          />
+        )}
 
         {/* Main Area */}
         <Box
@@ -293,8 +316,13 @@ const Layout = () => {
             backgroundColor: muiTheme.palette.background.default,
           }}
         >
-          {/* Navbar (static) */}
-          {MemoizedNavbar}
+          <NavbarPanel
+            darkMode={darkMode}
+            inviteModalOpen={inviteModalOpen}
+            toggleSidebar={toggleSidebar}
+            handleOpenInviteModal={handleOpenInviteModal}
+            handleCloseInviteModal={handleCloseInviteModal}
+          />
 
           {/* Scrollable Outlet */}
           <Box

--- a/src/utils/permissions.test.ts
+++ b/src/utils/permissions.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeRole,
+  getDefaultDashboardRoute,
+  isDashboardPathAllowedForRole,
+  isMenuVisibleForRole,
+} from './permissions';
+
+describe('normalizeRole', () => {
+  it('returns unknown for undefined input', () => {
+    expect(normalizeRole(undefined)).toBe('unknown');
+  });
+
+  it('handles all common spellings for system-admin', () => {
+    expect(normalizeRole('system-admin')).toBe('system-admin');
+    expect(normalizeRole('system_admin')).toBe('system-admin');
+    expect(normalizeRole('system admin')).toBe('system-admin');
+    expect(normalizeRole('SYSTEM-ADMIN')).toBe('system-admin');
+  });
+
+  it('handles network-admin variants', () => {
+    expect(normalizeRole('network-admin')).toBe('network-admin');
+    expect(normalizeRole('network_admin')).toBe('network-admin');
+  });
+
+  it('normalizes known roles correctly', () => {
+    expect(normalizeRole('admin')).toBe('admin');
+    expect(normalizeRole('manager')).toBe('manager');
+    expect(normalizeRole('employee')).toBe('employee');
+    expect(normalizeRole('user')).toBe('user');
+    expect(normalizeRole('hr-admin')).toBe('hr-admin');
+    expect(normalizeRole('hr_admin')).toBe('hr-admin');
+  });
+});
+
+describe('getDefaultDashboardRoute', () => {
+  it('routes admin roles to /dashboard', () => {
+    expect(getDefaultDashboardRoute('system-admin')).toBe('/dashboard');
+    expect(getDefaultDashboardRoute('network-admin')).toBe('/dashboard');
+    expect(getDefaultDashboardRoute('admin')).toBe('/dashboard');
+  });
+
+  it('routes hr-admin to AttendanceTable', () => {
+    expect(getDefaultDashboardRoute('hr-admin')).toBe('/dashboard/AttendanceTable');
+  });
+
+  it('routes manager to teams', () => {
+    expect(getDefaultDashboardRoute('manager')).toBe('/dashboard/teams');
+  });
+
+  it('routes employee and user to AttendanceCheck', () => {
+    expect(getDefaultDashboardRoute('employee')).toBe('/dashboard/AttendanceCheck');
+    expect(getDefaultDashboardRoute('user')).toBe('/dashboard/AttendanceCheck');
+  });
+
+  it('routes unknown roles to /dashboard', () => {
+    expect(getDefaultDashboardRoute(undefined)).toBe('/dashboard');
+    expect(getDefaultDashboardRoute('some-other-role')).toBe('/dashboard');
+  });
+});
+
+describe('isDashboardPathAllowedForRole', () => {
+  it('allows AttendanceCheck for employee', () => {
+    expect(isDashboardPathAllowedForRole('AttendanceCheck', 'employee')).toBe(true);
+  });
+
+  it('blocks employee from EmployeeManager', () => {
+    expect(isDashboardPathAllowedForRole('EmployeeManager', 'employee')).toBe(false);
+  });
+
+  it('allows admin to access EmployeeManager', () => {
+    expect(isDashboardPathAllowedForRole('EmployeeManager', 'admin')).toBe(true);
+  });
+
+  it('allows system-admin to access all major routes', () => {
+    const adminRoutes = ['EmployeeManager', 'AttendanceCheck', 'AttendanceTable', 'Designations', 'TenantEmployees'];
+    for (const route of adminRoutes) {
+      expect(isDashboardPathAllowedForRole(route, 'system-admin')).toBe(true);
+    }
+  });
+
+  it('allows empty path (dashboard index) for admin', () => {
+    expect(isDashboardPathAllowedForRole('', 'admin')).toBe(true);
+  });
+});
+
+describe('isMenuVisibleForRole', () => {
+  it('shows attendance menu for all roles except unknown', () => {
+    const roles = ['admin', 'manager', 'employee', 'user', 'hr-admin'];
+    for (const role of roles) {
+      expect(isMenuVisibleForRole('Attendance', role)).toBe(true);
+    }
+  });
+
+  it('hides tenant menu from employee and manager', () => {
+    expect(isMenuVisibleForRole('Tenant', 'employee')).toBe(false);
+    expect(isMenuVisibleForRole('Tenant', 'manager')).toBe(false);
+  });
+
+  it('shows tenant menu for system-admin', () => {
+    expect(isMenuVisibleForRole('Tenant', 'system-admin')).toBe(true);
+  });
+});

--- a/src/utils/roleUtils.test.ts
+++ b/src/utils/roleUtils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getRoleName,
+  hasRole,
+  isAdmin,
+  isManager,
+  isEmployee,
+  isSystemAdmin,
+} from './roleUtils';
+
+describe('getRoleName', () => {
+  it('returns the string when role is a string', () => {
+    expect(getRoleName('admin')).toBe('admin');
+    expect(getRoleName('manager')).toBe('manager');
+  });
+
+  it('extracts name from a role object', () => {
+    expect(getRoleName({ name: 'admin' })).toBe('admin');
+    expect(getRoleName({ name: 'employee', id: '1' })).toBe('employee');
+  });
+
+  it('returns Unknown for undefined', () => {
+    expect(getRoleName(undefined)).toBe('Unknown');
+  });
+});
+
+describe('hasRole', () => {
+  it('matches case-insensitively', () => {
+    expect(hasRole('Admin', 'admin')).toBe(true);
+    expect(hasRole('ADMIN', 'admin')).toBe(true);
+  });
+
+  it('returns false for non-matching roles', () => {
+    expect(hasRole('employee', 'admin')).toBe(false);
+  });
+
+  it('works with role objects', () => {
+    expect(hasRole({ name: 'admin' }, 'admin')).toBe(true);
+  });
+});
+
+describe('isAdmin / isManager / isEmployee / isSystemAdmin', () => {
+  it('correctly identifies admin', () => {
+    expect(isAdmin('admin')).toBe(true);
+    expect(isAdmin('manager')).toBe(false);
+  });
+
+  it('correctly identifies manager', () => {
+    expect(isManager('manager')).toBe(true);
+    expect(isManager('admin')).toBe(false);
+  });
+
+  it('correctly identifies employee', () => {
+    expect(isEmployee('employee')).toBe(true);
+    expect(isEmployee('user')).toBe(false);
+  });
+
+  it('correctly identifies system-admin', () => {
+    expect(isSystemAdmin('system-admin')).toBe(true);
+    expect(isSystemAdmin('admin')).toBe(false);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,6 +46,14 @@ export default defineConfig({
       {
         extends: true,
         test: {
+          name: 'unit',
+          environment: 'node',
+          include: ['src/**/*.test.ts'],
+        },
+      },
+      {
+        extends: true,
+        test: {
           name: 'storybook',
           browser: {
             enabled: true,


### PR DESCRIPTION
## Summary

**Layout memo fix:**
- Removes the `useMemo(JSX)` anti-pattern used for `MemoizedSidebar` and `MemoizedNavbar` in `Layout.tsx`
- `useMemo` is for memoizing values, not JSX trees — wrapping JSX in useMemo bypasses React's reconciler and prevents proper component lifecycle management
- Extracts `SidebarPanel` and `NavbarPanel` as `React.memo` function components defined at module level, giving the same render-skip benefit through the correct React API

**Smoke tests (27 tests, all passing):**
- Zero tests existed despite vitest being installed and configured
- Adds `src/utils/permissions.test.ts` — covers `normalizeRole`, `getDefaultDashboardRoute`, `isDashboardPathAllowedForRole`, `isMenuVisibleForRole`
- Adds `src/utils/roleUtils.test.ts` — covers `getRoleName`, `hasRole`, `isAdmin`, `isManager`, `isEmployee`, `isSystemAdmin`
- Configures a separate vitest `unit` project with `node` environment (no browser/DOM needed for pure utility tests)
- Adds `npm test` and `npm run test:watch` scripts

## Test plan

- [ ] `npm test` runs and all 27 tests pass
- [ ] Sidebar renders and toggles correctly on mobile and desktop
- [ ] Navbar renders correctly with dark/light mode
- [ ] Employee invite modal opens/closes via Navbar
- [ ] Type-check passes: `npm run type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)