### PR TITLE
fix(ts): replace loose object with SxProps<Theme> in common components

### DIFF
--- a/src/components/common/AppDropdown.tsx
+++ b/src/components/common/AppDropdown.tsx
@@ -8,6 +8,8 @@ import {
   useTheme,
   Checkbox,
   type SelectProps,
+  type SxProps,
+  type Theme,
 } from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import { Icons } from '../../assets/icons';
@@ -27,7 +29,7 @@ interface AppDropdownProps
   value: string | number | Array<string | number>;
   onChange: (event: SelectChangeEvent<string | number | string[]>) => void;
   labelClassName?: string;
-  containerSx?: object;
+  containerSx?: SxProps<Theme>;
   placeholder?: string;
   error?: boolean;
   helperText?: string;

--- a/src/components/common/AppFormModal.tsx
+++ b/src/components/common/AppFormModal.tsx
@@ -10,6 +10,8 @@ import {
   useMediaQuery,
   useTheme,
   CircularProgress,
+  type SxProps,
+  type Theme,
 } from '@mui/material';
 import { Close as CloseIcon } from '@mui/icons-material';
 import AppInputField from './AppInputField';
@@ -44,7 +46,7 @@ export interface AppFormModalProps {
   children?: ReactNode;
   hideActions?: boolean;
   wrapInForm?: boolean;
-  paperSx?: object;
+  paperSx?: SxProps<Theme>;
   submitLabel?: string;
   cancelLabel?: string;
   submitStartIcon?: ReactNode;

--- a/src/components/common/AppInputField.tsx
+++ b/src/components/common/AppInputField.tsx
@@ -7,13 +7,15 @@ import {
   InputAdornment,
   IconButton,
   type TextFieldProps,
+  type SxProps,
+  type Theme,
 } from '@mui/material';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 
 interface AppInputFieldProps extends Omit<TextFieldProps, 'label'> {
   label: string;
   labelClassName?: string;
-  containerSx?: object;
+  containerSx?: SxProps<Theme>;
   inputBackgroundColor?: string;
   hideErrorsOnSmallScreen?: boolean;
 }

--- a/src/components/common/AppTextarea.tsx
+++ b/src/components/common/AppTextarea.tsx
@@ -5,13 +5,15 @@ import {
   Box,
   useTheme,
   type TextFieldProps,
+  type SxProps,
+  type Theme,
 } from '@mui/material';
 
 export interface AppTextareaProps
   extends Omit<TextFieldProps, 'label' | 'multiline'> {
   label: string;
   labelClassName?: string;
-  containerSx?: object;
+  containerSx?: SxProps<Theme>;
   inputBackgroundColor?: string;
   /** When true, helperText is rendered below the textarea instead of next to the label */
   helperTextBelowInput?: boolean;


### PR DESCRIPTION
## Summary
- `AppInputField.containerSx`: `object` → `SxProps<Theme>`
- `AppTextarea.containerSx`: `object` → `SxProps<Theme>`
- `AppDropdown.containerSx`: `object` → `SxProps<Theme>`
- `AppFormModal.paperSx`: `object` → `SxProps<Theme>`

Using bare `object` silently accepts any value including invalid sx properties. `SxProps<Theme>` is the MUI-correct type and gives compile-time validation.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Visually confirm affected components render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)