### PR TITLE
fix(ts): remove explicit any types from AppButton, TeamMembersAvatar, AnnouncementModal

### DIFF
--- a/src/components/Announcements/AnnouncementModal.tsx
+++ b/src/components/Announcements/AnnouncementModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Checkbox, FormControlLabel, useTheme } from '@mui/material';
 import AppFormModal from '../common/AppFormModal';
 import DateTimePickerField from '../common/DateTimePickerField';
@@ -339,7 +339,10 @@ export default function AnnouncementModal({
         }
         onBlur={() => setTitleTouched(true)}
         onChange={(e: unknown) => {
-          const raw = typeof e === 'string' ? e : (e as any).target?.value || '';
+          const raw =
+            typeof e === 'string'
+              ? e
+              : (e as React.ChangeEvent<HTMLInputElement>).target?.value ?? '';
           setTitle(raw.slice(0, MAX_TITLE_LENGTH));
           setTitleApiError(null);
         }}

--- a/src/components/Teams/TeamMembersAvatar.tsx
+++ b/src/components/Teams/TeamMembersAvatar.tsx
@@ -17,6 +17,7 @@ import {
   InputAdornment,
   useTheme,
   SvgIcon,
+  type SvgIconProps,
 } from '@mui/material';
 import UserAvatar from '../common/UserAvatar';
 import { Avatar } from '@mui/material';
@@ -36,7 +37,7 @@ interface AdminTeamMember extends TeamMember {
 }
 import { getUserRole, isAdmin } from '../../utils/auth';
 
-const CustomSearchIcon = (props: any) => (
+const CustomSearchIcon = (props: SvgIconProps) => (
   <SvgIcon
     {...props}
     viewBox='0 0 17 17'

--- a/src/components/common/AppButton.tsx
+++ b/src/components/common/AppButton.tsx
@@ -14,8 +14,6 @@ interface AppButtonProps extends Omit<ButtonProps, 'children'> {
   text?: string;
   loading?: boolean;
   children?: React.ReactNode;
-  // Allow forwarding arbitrary props (e.g. `to` when using react-router Link)
-  [key: string]: any;
 }
 
 export function AppButton({


### PR DESCRIPTION
## Summary
- **AppButton**: removed unused `[key: string]: any` index signature — no callers pass arbitrary props; `ButtonProps` already covers all valid HTML button attributes
- **TeamMembersAvatar**: typed `CustomSearchIcon` props as `SvgIconProps` instead of `any`
- **AnnouncementModal**: replaced `(e as any).target?.value` with proper `React.ChangeEvent<HTMLInputElement>` narrowing

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Announcement modal title input still works correctly
- [ ] Team members avatar search icon renders as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)