### PR TITLE
fix(ts): add typed generics to axios calls in key API files

### DIFF
--- a/src/api/attendanceApi.ts
+++ b/src/api/attendanceApi.ts
@@ -80,6 +80,42 @@ export interface SystemAllAttendanceResponse {
   totalTenants: number;
 }
 
+export interface TodayTeamAttendanceMember {
+  user_id: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  profile_pic?: string;
+  designation?: string;
+  department?: string;
+  attendance: {
+    date: string;
+    checkIn: string;
+    checkInId: string;
+    checkOut: string | null;
+    checkOutId: string | null;
+    workedHours: number;
+    approvalStatus: string;
+    approvalRemarks: string | null;
+    approvedBy: string | null;
+    approvedAt: string | null;
+  }[];
+  totalDaysWorked: number;
+  totalHoursWorked: number;
+}
+
+export interface TodayTeamAttendanceResponse {
+  items: TodayTeamAttendanceMember[];
+  total: number;
+}
+
+export interface TeamAttendanceResponse {
+  items: AttendanceEvent[];
+  total: number;
+  page: number;
+  totalPages: number;
+}
+
 class AttendanceApiService {
   private baseUrl = '/attendance';
 
@@ -107,7 +143,7 @@ class AttendanceApiService {
         params.append('tenantId', tenantId);
       }
 
-      const response = await axiosInstance.get(
+      const response = await axiosInstance.get<AttendanceResponse>(
         `${this.baseUrl}/all?${params.toString()}`
       );
 
@@ -167,7 +203,7 @@ class AttendanceApiService {
 
       const url = `${this.baseUrl}/events?${params.toString()}`;
 
-      const response = await axiosInstance.get(url);
+      const response = await axiosInstance.get<AttendanceResponse>(url);
 
       if (response.data && response.data.items) {
         return response.data;
@@ -225,7 +261,7 @@ class AttendanceApiService {
 
       const url = `${this.baseUrl}?${params.toString()}`; // This hits the /attendance endpoint for daily summaries
 
-      const response = await axiosInstance.get(url);
+      const response = await axiosInstance.get<AttendanceResponse>(url);
 
       if (response.data && response.data.items) {
         return response.data;
@@ -269,7 +305,7 @@ class AttendanceApiService {
 
       const url = `${this.baseUrl}/today?${params.toString()}`;
 
-      const response = await axiosInstance.get(url);
+      const response = await axiosInstance.get<{ checkIn: string | null; checkOut: string | null }>(url);
 
       return response.data;
     } catch {
@@ -318,7 +354,7 @@ class AttendanceApiService {
     if (typeof input.latitude === 'number') body.latitude = input.latitude;
     if (typeof input.longitude === 'number') body.longitude = input.longitude;
 
-    const response = await axiosInstance.post(this.baseUrl, body);
+    const response = await axiosInstance.post<AttendanceEvent>(this.baseUrl, body);
     return response.data;
   }
 
@@ -346,7 +382,7 @@ class AttendanceApiService {
       if (tenantId) {
         params.append('tenantId', tenantId);
       }
-      const response = await axiosInstance.get(
+      const response = await axiosInstance.get<TeamAttendanceResponse>(
         `${this.baseUrl}/team?${params.toString()}`
       );
       return response.data;
@@ -361,34 +397,9 @@ class AttendanceApiService {
   }
 
   // Get today's attendance for all team members (Manager only)
-  async getTodayTeamAttendance(): Promise<{
-    items: {
-      user_id: string;
-      first_name: string;
-      last_name: string;
-      email: string;
-      profile_pic?: string;
-      designation?: string;
-      department?: string;
-      attendance: {
-        date: string;
-        checkIn: string;
-        checkInId: string;
-        checkOut: string | null;
-        checkOutId: string | null;
-        workedHours: number;
-        approvalStatus: string;
-        approvalRemarks: string | null;
-        approvedBy: string | null;
-        approvedAt: string | null;
-      }[];
-      totalDaysWorked: number;
-      totalHoursWorked: number;
-    }[];
-    total: number;
-  }> {
+  async getTodayTeamAttendance(): Promise<TodayTeamAttendanceResponse> {
     try {
-      const response = await axiosInstance.get(
+      const response = await axiosInstance.get<TodayTeamAttendanceResponse>(
         `${this.baseUrl}/team/today/attendance`
       );
       return response.data;

--- a/src/api/dashboardApi.ts
+++ b/src/api/dashboardApi.ts
@@ -11,7 +11,7 @@ export type DashboardKpi = {
 
 export async function getDashboardKpi(): Promise<DashboardKpi | null> {
   try {
-    const resp = await axiosInstance.get('/dashboard/kpi');
+    const resp = await axiosInstance.get<Record<string, unknown>>('/dashboard/kpi');
     const data = resp?.data ?? resp;
 
     const mapped: DashboardKpi = {
@@ -46,7 +46,7 @@ export type AttendanceRow = {
 
 export async function getAttendanceSummary(): Promise<AttendanceRow[]> {
   try {
-    const resp = await axiosInstance.get('/dashboard/attendance-summary');
+    const resp = await axiosInstance.get<Array<Record<string, unknown>>>('/dashboard/attendance-summary');
     const data = resp?.data ?? resp;
     if (!Array.isArray(data)) return [];
 

--- a/src/api/leaveReportApi.ts
+++ b/src/api/leaveReportApi.ts
@@ -210,7 +210,7 @@ class LeaveReportApiService {
 
   async exportLeaveSummaryCSV(year: number): Promise<Blob> {
     const { userId } = getUserFromLocalStorage();
-    const response = await axiosInstance.get(
+    const response = await axiosInstance.get<Blob>(
       `${this.baseUrl}/leave-summary/export`,
       {
         params: { employeeId: userId, year },
@@ -222,7 +222,7 @@ class LeaveReportApiService {
 
   async exportTeamLeaveSummaryCSV(month: number, year: number): Promise<Blob> {
     const { userId: managerId } = getUserFromLocalStorage();
-    const response = await axiosInstance.get(
+    const response = await axiosInstance.get<Blob>(
       `${this.baseUrl}/team-leave-summary/export`,
       {
         params: { managerId, month, year },
@@ -234,7 +234,7 @@ class LeaveReportApiService {
 
   async exportLeaveBalanceCSV(): Promise<Blob> {
     const { userId } = getUserFromLocalStorage();
-    const response = await axiosInstance.get(
+    const response = await axiosInstance.get<Blob>(
       `${this.baseUrl}/leave-balance/export`,
       {
         params: { employeeId: userId },
@@ -252,7 +252,7 @@ class LeaveReportApiService {
     const year = params?.year ?? new Date().getFullYear();
     const requestParams: { year: number; employeeName?: string } = { year };
     if (params?.employeeName) requestParams.employeeName = params.employeeName;
-    const response = await axiosInstance.get(
+    const response = await axiosInstance.get<Blob>(
       `${this.baseUrl}/export/all-leave-reports`,
       { params: requestParams, responseType: 'blob' }
     );

--- a/src/api/reportApi.ts
+++ b/src/api/reportApi.ts
@@ -1,5 +1,13 @@
 import axiosInstance from './axiosInstance';
 
+export interface AttendanceSummaryResponse {
+  items: Record<string, unknown>[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
 class AttendanceSummaryApi {
   private baseUrl = '/reports/attendance-summary';
 
@@ -7,20 +15,14 @@ class AttendanceSummaryApi {
     tenantId: string,
     days: number = 30,
     page: number = 1
-  ): Promise<{
-    items: Record<string, unknown>[];
-    total: number;
-    page: number;
-    limit: number;
-    totalPages: number;
-  }> {
+  ): Promise<AttendanceSummaryResponse> {
     try {
       const params = new URLSearchParams({
         tenantId,
         days: days.toString(),
         page: page.toString(),
       });
-      const response = await axiosInstance.get(
+      const response = await axiosInstance.get<AttendanceSummaryResponse>(
         `${this.baseUrl}?${params.toString()}`
       );
       return response.data;


### PR DESCRIPTION
## Summary

All untyped `axiosInstance.get/post()` calls cause `response.data` to implicitly be `any`, bypassing TypeScript entirely for API responses. This PR adds proper response type generics across the most-used API files.

### Changes per file

| File | Calls fixed | Notes |
|---|---|---|
| `dashboardApi.ts` | 2 | `get<Record<string,unknown>>` for KPI and attendance summary |
| `reportApi.ts` | 1 | Extracted `AttendanceSummaryResponse` interface; added `get<T>` |
| `leaveReportApi.ts` | 4 | `get<Blob>` for all CSV export endpoints |
| `attendanceApi.ts` | 7 | Added generics to all calls; extracted `TodayTeamAttendanceResponse`, `TodayTeamAttendanceMember`, and `TeamAttendanceResponse` interfaces to replace large inline return types |

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Dashboard KPI and attendance summary load correctly
- [ ] CSV exports download successfully
- [ ] Attendance table shows correct data for all roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)