### PR TITLE
feat: Claude automated PR review via GitHub Actions

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,142 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+      - master
+      - dev
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch diff and build Claude payload
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          # Fetch the PR diff via gh CLI (falls back to git diff)
+          gh pr diff "$PR_NUMBER" > pr.diff 2>/dev/null || \
+            git diff "origin/${BASE_REF}...HEAD" > pr.diff
+
+          # Build JSON payload using Python for safe escaping
+          python3 << 'PYEOF'
+          import json, os
+
+          pr_title = os.environ.get('PR_TITLE', '(no title)')
+          pr_body  = os.environ.get('PR_BODY', '').strip() or '(no description)'
+
+          with open('pr.diff', 'r', errors='replace') as f:
+              diff = f.read()
+
+          # Truncate diff to ~80 KB to stay within Claude's token budget
+          MAX_DIFF_BYTES = 80_000
+          if len(diff.encode()) > MAX_DIFF_BYTES:
+              diff = diff.encode()[:MAX_DIFF_BYTES].decode(errors='replace')
+              diff += '\n\n... [diff truncated — too large to display in full] ...'
+
+          prompt = f"""You are a senior software engineer performing a pull-request code review.
+The project is a React 18 + TypeScript SPA (Vite, MUI v7, React Router v7).
+
+**PR title:** {pr_title}
+**PR description:**
+{pr_body}
+
+**Diff:**
+```diff
+{diff}
+```
+
+Please provide a structured code review with these sections:
+
+## Overview
+Brief summary of what this PR does.
+
+## Code Quality
+TypeScript correctness, React patterns, component design, naming, readability.
+
+## Issues & Risks
+Any bugs, edge cases, security concerns, or performance problems.
+
+## Suggestions
+Concrete improvement ideas with short code examples where helpful.
+
+## Verdict
+One of: ✅ **Approve** | ⚠️ **Request Changes** | 💬 **Comment**
+One-sentence rationale.
+
+Keep the review concise and actionable. Use GitHub-flavoured markdown."""
+
+          payload = {
+              "model": "claude-sonnet-4-6",
+              "max_tokens": 4096,
+              "messages": [{"role": "user", "content": prompt}],
+          }
+
+          with open('payload.json', 'w') as f:
+              json.dump(payload, f)
+
+          print("✅ Payload written to payload.json")
+          PYEOF
+
+      - name: Call Claude API
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          curl -sf https://api.anthropic.com/v1/messages \
+            -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d @payload.json \
+            -o response.json
+
+          echo "✅ Claude API response received"
+
+      - name: Extract review and post comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 << 'PYEOF'
+          import json, os, subprocess, sys
+
+          with open('response.json', 'r') as f:
+              response = json.load(f)
+
+          if 'error' in response:
+              err = response['error']
+              review = f"⚠️ Claude API error: **{err.get('type', 'unknown')}** — {err.get('message', 'no message')}"
+          elif response.get('content'):
+              review = response['content'][0].get('text', '_(empty response)_')
+          else:
+              review = "_(Claude returned an unexpected response format)_"
+
+          sha = os.environ.get('GITHUB_SHA', '')[:7]
+          comment = (
+              "## Claude Code Review 🤖\n\n"
+              + review
+              + f"\n\n---\n*Reviewed commit `{sha}` · Powered by [Claude](https://www.anthropic.com/claude)*"
+          )
+
+          with open('review_comment.txt', 'w') as f:
+              f.write(comment)
+
+          print("✅ Review comment written")
+          PYEOF
+
+          gh pr comment "$PR_NUMBER" --body-file review_comment.txt
+          echo "✅ Review posted to PR #${PR_NUMBER}"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-pr-review.yml` — triggers on every PR opened/updated against `main`, `master`, or `dev`
- Fetches the PR diff, sends it to Claude (`claude-sonnet-4-6`) with a structured review prompt
- Claude posts a review comment directly on the PR with sections: Overview, Code Quality, Issues & Risks, Suggestions, Verdict
- Uses `ANTHROPIC_API_KEY` secret (already configured in repo settings) and the built-in `GITHUB_TOKEN` for posting comments
- Diffs are truncated to 80 KB to stay within Claude's token budget

## How it works
1. `gh pr diff` fetches the PR diff
2. Python builds the JSON payload (handles all escaping safely)
3. `curl` calls `https://api.anthropic.com/v1/messages`
4. Python extracts the review text from the response
5. `gh pr comment --body-file` posts the review comment

## Test plan
- [ ] Open a test PR targeting `dev` or `main` and verify a Claude review comment appears
- [ ] Verify the workflow fails gracefully when `ANTHROPIC_API_KEY` is missing/invalid (posts an error message rather than crashing silently)
- [ ] Check that a very large diff is truncated rather than failing the API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)