### PR TITLE
refactor(theme): introduce design token layer with Figma brand colors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,11 @@ import tseslint from 'typescript-eslint';
 export default tseslint.config(
   [
     { ignores: ['dist', 'node_modules', 'build', 'coverage'] },
+    // tokens.ts is the only file allowed to contain raw hex color literals.
+    {
+      files: ['src/theme/tokens.ts'],
+      rules: { 'no-restricted-syntax': 'off' },
+    },
     {
       files: ['**/*.{ts,tsx}'],
       extends: [
@@ -26,6 +31,20 @@ export default tseslint.config(
         },
       },
       rules: {
+        // ── Design tokens — ban raw hex values outside tokens.ts ──────
+        // All colors must live in src/theme/tokens.ts; components use
+        // theme.palette.* or MUI sx shorthand ('primary.main') instead.
+        // Warn on hex literals; will be promoted to 'error' once existing
+        // violations are cleaned up component-by-component.
+        'no-restricted-syntax': [
+          'warn',
+          {
+            selector:
+              'Literal[value=/^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/]',
+            message:
+              'Hardcoded hex color detected. Add the color to src/theme/tokens.ts and reference it via theme.palette.* or an MUI sx shorthand.',
+          },
+        ],
         // ── TypeScript ────────────────────────────────────────────────
         // Unused vars: allow underscore-prefixed names to be ignored
         '@typescript-eslint/no-unused-vars': [

--- a/src/components/Attendance/LeaveSummaryChart.tsx
+++ b/src/components/Attendance/LeaveSummaryChart.tsx
@@ -41,7 +41,8 @@ const mockData: Record<string, { name: string; value: number }[]> = {
   ],
 };
 
-const COLORS = ['#8884d8', '#82ca9d', '#ffc658'];
+import { colorTokens } from '../../theme';
+const CHART_COLORS = colorTokens.chart;
 
 const LeaveSummaryChart: React.FC = () => {
   const [selected, setSelected] = useState('Ali');
@@ -87,7 +88,7 @@ const LeaveSummaryChart: React.FC = () => {
               label
             >
               {chartData.map((_entry, i) => (
-                <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
               ))}
             </Pie>
             <Tooltip />

--- a/src/components/Auth/ConfirmPassword.tsx
+++ b/src/components/Auth/ConfirmPassword.tsx
@@ -15,7 +15,6 @@ import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { validatePasswordStrength } from '../../utils/validation';
 import authApi from '../../api/authApi';
 import AppButton from '../common/AppButton';
-import { COLORS } from '../../constants/appConstants';
 
 const PasswordReset: React.FC = () => {
   const navigate = useNavigate();
@@ -128,7 +127,7 @@ const PasswordReset: React.FC = () => {
             variant='contained'
             text='Back to Login'
             onClick={() => navigate('/', { replace: true })}
-            sx={{ backgroundColor: COLORS.PRIMARY }}
+            sx={{ backgroundColor: 'primary.main' }}
           />
         </Paper>
       </Box>

--- a/src/components/HRPoliciesModule/PolicyForm.tsx
+++ b/src/components/HRPoliciesModule/PolicyForm.tsx
@@ -13,7 +13,6 @@ import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import type { Policy } from '../../types/policy';
 import AppButton from '../common/AppButton';
-import { COLORS } from '../../constants/appConstants';
 
 interface PolicyFormProps {
   open: boolean;
@@ -173,7 +172,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
           variant='contained'
           text={initialData ? 'Update' : 'Add'}
           onClick={handleSubmit}
-          sx={{ backgroundColor: COLORS.PRIMARY }}
+          sx={{ backgroundColor: 'primary.main' }}
         />
       </DialogActions>
     </Dialog>

--- a/src/components/HRPoliciesModule/PolicyList.tsx
+++ b/src/components/HRPoliciesModule/PolicyList.tsx
@@ -17,7 +17,6 @@ import PolicyForm from './PolicyForm';
 import edit from '../../assets/dashboardIcon/edit.svg';
 import deleteIcon from '../../assets/dashboardIcon/ui-delete.svg';
 import { useOutletContext } from 'react-router-dom';
-import { COLORS } from '../../constants/appConstants';
 
 const PolicyList: React.FC = () => {
   const [policies, setPolicies] = useState<Policy[]>(mockPolicies);
@@ -62,7 +61,7 @@ const PolicyList: React.FC = () => {
             setSelected(null);
             setOpenForm(true);
           }}
-          sx={{ backgroundColor: COLORS.PRIMARY }}
+          sx={{ backgroundColor: 'primary.main' }}
         >
           Add Policy
         </Button>

--- a/src/components/HolidayCalendar/HolidayList.tsx
+++ b/src/components/HolidayCalendar/HolidayList.tsx
@@ -6,7 +6,6 @@ import AddHolidayDialog from './AddHolidayDialog';
 import HolidayCalendarView from './HolidayCalendarView';
 import UpcomingHolidayList from './UpcomingHolidayList';
 import AppButton from '../common/AppButton';
-import { COLORS } from '../../constants/appConstants';
 
 export interface Holiday {
   id: string;
@@ -32,7 +31,7 @@ const HolidayList: React.FC = () => {
   ]);
 
   const [open, setOpen] = useState(false);
-  const { darkMode } = useOutletContext<{ darkMode: boolean }>();
+  const { darkMode: _darkMode } = useOutletContext<{ darkMode: boolean }>();
 
   const handleAddHoliday = (newHoliday: Holiday) => {
     setHolidays(prev => [...prev, newHoliday]);
@@ -49,17 +48,14 @@ const HolidayList: React.FC = () => {
           mb: 2,
         }}
       >
-        <Typography
-          variant='h5'
-          sx={{ color: darkMode ? COLORS.DARK_TEXT : COLORS.LIGHT_TEXT }}
-        >
+        <Typography variant='h5' sx={{ color: 'text.primary' }}>
           Holiday List
         </Typography>
         <AppButton
           variant='contained'
           text='Add Holiday'
           onClick={() => setOpen(true)}
-          sx={{ backgroundColor: COLORS.PRIMARY }}
+          sx={{ backgroundColor: 'primary.main' }}
         />
       </Box>
       <Box

--- a/src/components/ManagementUI/UserList.tsx
+++ b/src/components/ManagementUI/UserList.tsx
@@ -24,14 +24,13 @@ import {
   users as mockUsers,
 } from '../../Data/userMock';
 import AppButton from '../common/AppButton';
-import { COLORS } from '../../constants/appConstants';
 
 const UserList: React.FC = () => {
   const [users, setUsers] = useState<User[]>(mockUsers);
   const [open, setOpen] = useState(false);
   const [editUser, setEditUser] = useState<User | undefined>(undefined);
   const [filters, setFilters] = useState({ department: '', designation: '' });
-  const { darkMode } = useOutletContext<{ darkMode: boolean }>();
+  const { darkMode: _darkMode } = useOutletContext<{ darkMode: boolean }>();
   const theme = useTheme();
 
   const filteredUsers = users.filter(user => {
@@ -68,11 +67,7 @@ const UserList: React.FC = () => {
   };
   return (
     <Box p={0}>
-      <Typography
-        variant='h5'
-        gutterBottom
-        sx={{ color: darkMode ? COLORS.DARK_TEXT : COLORS.LIGHT_TEXT }}
-      >
+      <Typography variant='h5' gutterBottom sx={{ color: 'text.primary' }}>
         User Management UI
       </Typography>
 

--- a/src/components/Teams/TeamList.tsx
+++ b/src/components/Teams/TeamList.tsx
@@ -35,7 +35,7 @@ import AvailableEmployees from './AvailableEmployees';
 import { exportCSV } from '../../api/exportApi';
 import { isAdmin, isHRAdmin } from '../../utils/auth';
 import { Icons } from '../../assets/icons';
-import { COLORS } from '../../constants/appConstants';
+import { colorTokens } from '../../theme';
 
 interface TeamListProps {
   teams?: Team[];
@@ -105,20 +105,8 @@ const TeamList: React.FC<TeamListProps> = ({
 
   // Generate avatar color
   const generateAvatarColor = (name: string): string => {
-    const colors = [
-      '#1976d2',
-      '#388e3c',
-      '#f57c00',
-      COLORS.ERROR,
-      '#7b1fa2',
-      '#303f9f',
-      '#ff6f00',
-      '#388e3c',
-      '#c2185b',
-      '#0097a7',
-    ];
-    const index = name.charCodeAt(0) % colors.length;
-    return colors[index];
+    const index = name.charCodeAt(0) % colorTokens.avatar.length;
+    return colorTokens.avatar[index];
   };
 
   const handleViewMembers = (team: Team) => {

--- a/src/components/common/Error404.tsx
+++ b/src/components/common/Error404.tsx
@@ -3,7 +3,6 @@ import { Box, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import AppButton from './AppButton';
-import { COLORS } from '../../constants/appConstants';
 
 const Error404: React.FC = () => {
   const navigate = useNavigate();
@@ -21,7 +20,7 @@ const Error404: React.FC = () => {
         p: 3,
       }}
     >
-      <ErrorOutlineIcon sx={{ fontSize: 120, color: COLORS.ACCENT, mb: 2 }} />
+      <ErrorOutlineIcon sx={{ fontSize: 120, color: 'warning.main', mb: 2 }} />
       <Typography variant='h1' sx={{ fontWeight: 700, fontSize: 64, mb: 1 }}>
         404
       </Typography>
@@ -38,7 +37,7 @@ const Error404: React.FC = () => {
         text='Go to Home'
         onClick={() => navigate('/')}
         sx={{
-          bgcolor: COLORS.PRIMARY,
+          bgcolor: 'primary.main',
           color: 'white',
           fontWeight: 600,
           borderRadius: 2,

--- a/src/constants/appConstants.ts
+++ b/src/constants/appConstants.ts
@@ -22,25 +22,6 @@ export const PAGINATION = {
   MOBILE_PAGE_SIZE_OPTIONS: [5, 10] as const,
 } as const;
 
-export const COLORS = {
-  PRIMARY: '#464b8a',
-  ACCENT: '#f19828',
-  SUCCESS: '#4caf50',
-  ERROR: '#d32f2f',
-  WARNING: '#ff9800',
-  INFO: '#1976d2',
-  DARK_BG: '#1e1e1e',
-  LIGHT_BG: '#fff',
-  DARK_TEXT: '#8f8f8f',
-  LIGHT_TEXT: '#000',
-  DARK_BORDER: '#333',
-  LIGHT_BORDER: '#ddd',
-  DARK_FIELD_BG: '#2e2e2e',
-  LIGHT_FIELD_BG: '#f1f1f1',
-  DARK_CARD_BG: '#2a2a2a',
-  LIGHT_CARD_BG: '#f9f9f9',
-} as const;
-
 export const SIZES = {
   AVATAR: {
     SMALL: 40,

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,3 +1,7 @@
+// Design tokens — chart/avatar palettes available here for non-component use
+export { colorTokens } from './tokens';
+export type { ColorTokens } from './tokens';
+
 // Theme configuration
 export { createAppTheme } from './themeConfig';
 export type { AppTheme, AppPalette } from './themeConfig';

--- a/src/theme/themeConfig.ts
+++ b/src/theme/themeConfig.ts
@@ -1,126 +1,79 @@
 import { createTheme } from '@mui/material/styles';
 import type { ThemeOptions } from '@mui/material/styles';
+import { colorTokens as t } from './tokens';
 
-// Light theme palette
+// ── Palettes ──────────────────────────────────────────────────────────────────
+
 const lightPalette = {
-  mode: 'light' as 'light' | 'dark',
+  mode: 'light' as const,
   primary: {
-    main: '#3083DC',
-    light: '#5ba0f0',
-    dark: '#2462a5',
-    contrastText: '#ffffff',
+    main: t.brand.primary,
+    light: t.brand.primaryLight,
+    dark: t.brand.primaryDark,
+    contrastText: t.neutral.white,
   },
   secondary: {
-    main: '#464b8a',
-    light: '#6b6fa8',
-    dark: '#2f3345',
-    contrastText: '#ffffff',
+    main: t.brand.secondary,
+    light: t.brand.secondaryLight,
+    dark: t.brand.secondaryDark,
+    contrastText: t.neutral.white,
   },
   background: {
-    default: '#f5f5f5',
-    paper: '#ffffff',
+    default: t.surface.light.bgDefault,
+    paper: t.surface.light.bgPaper,
   },
   text: {
-    primary: '#000000',
-    secondary: '#666666',
+    primary: t.surface.light.textPrimary,
+    secondary: t.surface.light.textSecondary,
   },
-  divider: '#e0e0e0',
+  divider: t.surface.light.divider,
+  success: { main: t.semantic.successLight },
+  error: { main: t.semantic.errorLight },
+  warning: { main: t.semantic.warningLight, contrastText: t.neutral.white },
+  info: { main: t.semantic.infoLight },
   action: {
     hover: 'rgba(0, 0, 0, 0.04)',
     selected: 'rgba(0, 0, 0, 0.08)',
   },
-  card: {
-    background: '#ffffff',
-    border: '#f0f0f0',
-    text: '#000000',
-  },
-  table: {
-    background: '#ffffff',
-    headerBackground: '#fafafa',
-    border: '#e0e0e0',
-  },
-  form: {
-    background: '#ffffff',
-    border: '#ccc',
-    text: '#000000',
-    label: '#000000',
-  },
-  button: {
-    primary: '#3083DC',
-    primaryHover: '#5ba0f0',
-    secondary: '#464b8a',
-    secondaryHover: '#6b6fa8',
-  },
-  status: {
-    success: '#4caf50',
-    error: '#f44336',
-    warning: '#ff9800',
-    info: '#2196f3',
-  },
 };
 
-// Dark theme palette
 const darkPalette = {
-  mode: 'dark' as 'light' | 'dark',
+  mode: 'dark' as const,
   primary: {
-    main: '#2462a5', // --primary-light-color
-    light: '#5ba0f0',
-    dark: '#1a4d7a',
-    contrastText: '#ffffff',
+    main: t.brand.primary,
+    light: t.brand.primaryMedium, // lighter variant for dark-bg contrast
+    dark: t.brand.primaryDark,
+    contrastText: t.neutral.white,
   },
   secondary: {
-    main: '#6b6fa8',
-    light: '#8a8fc7',
-    dark: '#4f527a',
-    contrastText: '#ffffff',
+    main: t.brand.secondary,
+    light: t.brand.secondaryLight,
+    dark: t.brand.secondaryDark,
+    contrastText: t.neutral.white,
   },
   background: {
-    default: '#121212',
-    paper: '#1e1e1e',
+    default: t.surface.dark.bgDefault,
+    paper: t.surface.dark.bgPaper,
   },
   text: {
-    primary: '#8f8f8f',
-    secondary: '#8f8f8f',
+    primary: t.surface.dark.textPrimary,
+    secondary: t.surface.dark.textSecondary,
   },
-  divider: '#333333',
+  divider: t.surface.dark.divider,
+  success: { main: t.semantic.successDark },
+  error: { main: t.semantic.errorDark },
+  warning: { main: t.semantic.warningDark, contrastText: t.neutral.white },
+  info: { main: t.semantic.infoDark },
   action: {
     hover: 'rgba(255, 255, 255, 0.08)',
     selected: 'rgba(255, 255, 255, 0.16)',
   },
-  card: {
-    background: '#222222',
-    border: '#333333',
-    text: '#ffffff',
-  },
-  table: {
-    background: '#333333',
-    headerBackground: '#2a2a2a',
-    border: '#555555',
-  },
-  form: {
-    background: '#2e2e2e',
-    border: '#555555',
-    text: '#ffffff',
-    label: '#cccccc',
-  },
-  button: {
-    primary: '#2462a5', // --primary-light-color
-    primaryHover: '#5ba0f0',
-    secondary: '#6b6fa8',
-    secondaryHover: '#8a8fc7',
-  },
-  status: {
-    success: '#66bb6a',
-    error: '#ef5350',
-    warning: '#ffb74d',
-    info: '#42a5f5',
-  },
 };
 
-// Common options for both themes
+// ── Shared component / typography options ─────────────────────────────────────
+
 const commonThemeOptions: ThemeOptions = {
   typography: {
-    // Use global SF Pro Display font (loaded in App.css)
     fontFamily:
       '"SF Pro Rounded", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
     h1: { fontWeight: 700 },
@@ -148,14 +101,14 @@ const commonThemeOptions: ThemeOptions = {
       styleOverrides: {
         root: {
           boxShadow: 'none',
-          border: '1px solid var(--mui-palette-card-border)',
+          border: '1px solid var(--app-divider)',
         },
       },
     },
     MuiPaper: {
       styleOverrides: {
         root: {
-          backgroundImage: 'var(--mui-palette-form-background)',
+          backgroundImage: 'none',
         },
       },
     },
@@ -163,20 +116,20 @@ const commonThemeOptions: ThemeOptions = {
       styleOverrides: {
         root: {
           '& .MuiOutlinedInput-root': {
-            backgroundColor: 'var(--mui-palette-form-background)',
-            color: 'var(--mui-palette-form-text)',
+            backgroundColor: 'var(--app-form-bg)',
+            color: 'var(--app-text-primary)',
             '& fieldset': {
-              borderColor: 'var(--mui-palette-divider)',
+              borderColor: 'var(--app-divider)',
             },
             '&:hover fieldset': {
-              borderColor: 'var(--mui-palette-primary-main)',
+              borderColor: 'var(--app-primary)',
             },
             '&.Mui-focused fieldset': {
-              borderColor: 'var(--mui-palette-primary-main)',
+              borderColor: 'var(--app-primary)',
             },
           },
           '& .MuiInputLabel-root': {
-            color: 'var(--mui-palette-form-label)',
+            color: 'var(--app-text-secondary)',
           },
         },
       },
@@ -184,21 +137,21 @@ const commonThemeOptions: ThemeOptions = {
     MuiSelect: {
       styleOverrides: {
         select: {
-          backgroundColor: 'var(--mui-palette-form-background)',
-          color: 'var(--mui-palette-form-text)',
+          backgroundColor: 'var(--app-form-bg)',
+          color: 'var(--app-text-primary)',
         },
         icon: {
-          color: 'var(--mui-palette-form-text)',
+          color: 'var(--app-text-primary)',
         },
         outlined: {
           '& .MuiOutlinedInput-notchedOutline': {
-            borderColor: 'var(--mui-palette-divider)',
+            borderColor: 'var(--app-divider)',
           },
           '&:hover .MuiOutlinedInput-notchedOutline': {
-            borderColor: 'var(--mui-palette-primary-main)',
+            borderColor: 'var(--app-primary)',
           },
           '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-            borderColor: 'var(--mui-palette-primary-main)',
+            borderColor: 'var(--app-primary)',
           },
         },
       },
@@ -208,7 +161,7 @@ const commonThemeOptions: ThemeOptions = {
         root: {
           '& .MuiTableCell-root': {
             fontWeight: 700,
-            backgroundColor: 'var(--mui-palette-table-headerBackground)',
+            backgroundColor: 'var(--app-table-header-bg)',
           },
         },
       },
@@ -216,19 +169,21 @@ const commonThemeOptions: ThemeOptions = {
     MuiTableCell: {
       styleOverrides: {
         root: {
-          borderColor: 'var(--mui-palette-table-border)',
+          borderColor: 'var(--app-divider)',
         },
       },
     },
     MuiTableContainer: {
       styleOverrides: {
         root: {
-          backgroundColor: 'var(--mui-palette-table-background)',
+          backgroundColor: 'var(--app-bg-paper)',
         },
       },
     },
   },
 };
+
+// ── Theme factory ─────────────────────────────────────────────────────────────
 
 export const createAppTheme = (mode: 'light' | 'dark') => {
   const palette = mode === 'dark' ? darkPalette : lightPalette;
@@ -239,47 +194,59 @@ export const createAppTheme = (mode: 'light' | 'dark') => {
     components: {
       ...commonThemeOptions.components,
 
-      // MuiPickersDay styleOverrides should be applied via ThemeProvider from @mui/x-date-pickers in your app entry point.
-
-      // CSS Variables
       MuiCssBaseline: {
         styleOverrides: {
+          // CSS custom properties derived from the active palette.
+          // Renamed to `--app-*` to avoid conflicts with MUI internal vars.
+          // These are the only CSS variables components & CSS files should use.
           ':root': {
+            '--app-primary': palette.primary.main,
+            '--app-primary-light': palette.primary.light,
+            '--app-primary-dark': palette.primary.dark,
+            '--app-secondary': palette.secondary.main,
+            '--app-bg-default': palette.background.default,
+            '--app-bg-paper': palette.background.paper,
+            '--app-text-primary': palette.text.primary,
+            '--app-text-secondary': palette.text.secondary,
+            '--app-divider': palette.divider,
+            '--app-form-bg': palette.background.paper,
+            '--app-table-header-bg':
+              mode === 'dark' ? t.neutral.grey800 : t.neutral.grey50,
+            '--app-success': palette.success.main,
+            '--app-error': palette.error.main,
+            '--app-warning': palette.warning.main,
+            '--app-info': palette.info.main,
+            // Backwards-compat aliases for CSS files that still use old names.
             '--mui-palette-divider': palette.divider,
-            '--mui-palette-table-background': palette.table.background,
-            '--mui-palette-table-headerBackground':
-              palette.table.headerBackground,
-            '--mui-palette-table-border': palette.table.border,
-            '--mui-palette-card-background': palette.card.background,
-            '--mui-palette-card-border': palette.card.border,
-            '--mui-palette-card-text': palette.card.text,
-            '--mui-palette-form-background': palette.form.background,
-            '--mui-palette-form-border': palette.form.border,
-            '--mui-palette-form-text': palette.form.text,
-            '--mui-palette-form-label': palette.form.label,
-            '--mui-palette-button-primary': palette.button.primary,
-            '--mui-palette-button-primaryHover': palette.button.primaryHover,
-            '--mui-palette-button-secondary': palette.button.secondary,
-            '--mui-palette-button-secondaryHover':
-              palette.button.secondaryHover,
-            '--mui-palette-status-success': palette.status.success,
-            '--mui-palette-status-error': palette.status.error,
-            '--mui-palette-status-warning': palette.status.warning,
-            '--mui-palette-status-info': palette.status.info,
             '--mui-palette-primary-main': palette.primary.main,
+            '--mui-palette-table-background': palette.background.paper,
+            '--mui-palette-table-headerBackground':
+              mode === 'dark' ? t.neutral.grey800 : t.neutral.grey50,
+            '--mui-palette-table-border': palette.divider,
+            '--mui-palette-card-background': palette.background.paper,
+            '--mui-palette-card-border': palette.divider,
+            '--mui-palette-form-background': palette.background.paper,
+            '--mui-palette-form-border': palette.divider,
+            '--mui-palette-form-text': palette.text.primary,
+            '--mui-palette-form-label': palette.text.secondary,
+            '--mui-palette-status-success': palette.success.main,
+            '--mui-palette-status-error': palette.error.main,
+            '--mui-palette-status-warning': palette.warning.main,
+            '--mui-palette-status-info': palette.info.main,
           },
           body: {
             color: palette.text.primary,
           },
           '.MuiTooltip-tooltip': {
-            backgroundColor: '#c0bdbd !important',
-            color: '#000000 !important',
+            backgroundColor: `${t.neutral.tooltip} !important`,
+            color: `${t.neutral.black} !important`,
           },
           '.MuiTooltip-arrow': {
-            color: '#c0bdbd !important',
+            color: `${t.neutral.tooltip} !important`,
           },
         },
       },
+
       MuiDialog: {
         defaultProps: {
           fullWidth: true,
@@ -289,7 +256,6 @@ export const createAppTheme = (mode: 'light' | 'dark') => {
             maxWidth: '900px',
             width: '92%',
             maxHeight: '85vh',
-            // ensure on very large screens the dialog doesn't get too wide
             '@media (min-width:1200px)': {
               width: '900px',
             },

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -1,0 +1,114 @@
+/**
+ * Design token definitions — single source of truth for all raw color values.
+ *
+ * These names mirror the Figma variable naming convention 1-to-1.
+ * This is the ONLY file in the codebase that may contain raw hex values.
+ *
+ * How to update colors:
+ *   1. Designer updates Figma.
+ *   2. Update the token(s) here.
+ *   3. Every component that reads from the MUI theme picks up the change automatically.
+ *
+ * Components must NEVER import from this file directly — they should always
+ * consume colors via `theme.palette.*` or MUI sx shorthand (`'primary.main'`).
+ */
+
+export const colorTokens = {
+  // ── Brand ─────────────────────────────────────────────────────────────────
+  // Figma page: Foundations / Colors / Brand
+  brand: {
+    primary: '#2680D9', // Figma: Primary Blue
+    primaryLight: '#E9F2FB', // Figma: Light Blue  (tint, hover bg, chip bg)
+    primaryDark: '#0059B2', // Figma: Dark Blue   (pressed / AAA text)
+    primaryMedium: '#5ba0f0', // mid-range for dark-mode `primary.light` slot
+
+    secondary: '#E51A5D', // Figma: Secondary
+    secondaryLight: '#F06A92', // ~lighten(secondary, 20%)
+    secondaryDark: '#B3154A', // ~darken(secondary, 20%)
+
+    accent: '#F19828', // warm amber — charts, highlights, warning accents
+  },
+
+  // ── Neutral scale ─────────────────────────────────────────────────────────
+  // Figma page: Foundations / Colors / Neutral
+  neutral: {
+    white: '#ffffff',
+    grey50: '#f9f9f9',
+    grey100: '#f5f5f5',
+    grey200: '#f0f0f0',
+    grey300: '#e0e0e0',
+    grey400: '#cccccc',
+    grey500: '#8f8f8f',
+    grey600: '#666666',
+    grey700: '#555555',
+    grey800: '#2c2c2c',
+    black: '#000000',
+
+    // Dark-mode surface divider (heavier than grey300)
+    darkDivider: '#333333',
+    // Tooltip background (neutral warm-grey)
+    tooltip: '#c0bdbd',
+  },
+
+  // ── Semantic status ────────────────────────────────────────────────────────
+  // Separate light/dark variants so the theme can swap correctly per mode.
+  semantic: {
+    successLight: '#4caf50',
+    successDark: '#66bb6a',
+    errorLight: '#f44336',
+    errorDark: '#ef5350',
+    warningLight: '#ff9800',
+    warningDark: '#ffb74d',
+    infoLight: '#2196f3',
+    infoDark: '#42a5f5',
+  },
+
+  // ── Surface (mode-specific) ────────────────────────────────────────────────
+  surface: {
+    light: {
+      bgDefault: '#f5f5f5',
+      bgPaper: '#ffffff',
+      textPrimary: '#000000',
+      textSecondary: '#666666',
+      divider: '#e0e0e0',
+    },
+    dark: {
+      bgDefault: '#121212',
+      bgPaper: '#1e1e1e',
+      textPrimary: '#8f8f8f',
+      textSecondary: '#8f8f8f',
+      divider: '#333333',
+    },
+  },
+
+  // ── Data visualisation ─────────────────────────────────────────────────────
+  // Ordered palette for charts — brand colors first, then complementary.
+  chart: [
+    '#2680D9', // primary
+    '#E51A5D', // secondary
+    '#F19828', // accent
+    '#4caf50', // success-green
+    '#9c27b0', // purple
+    '#00bcd4', // cyan
+    '#8884d8', // soft indigo
+    '#82ca9d', // soft green
+  ] as readonly string[],
+
+  // ── Avatar initials backgrounds ────────────────────────────────────────────
+  avatar: [
+    '#2680D9',
+    '#E51A5D',
+    '#F19828',
+    '#4caf50',
+    '#9c27b0',
+    '#00bcd4',
+    '#795548',
+    '#607d8b',
+    '#f44336',
+    '#3f51b5',
+    '#009688',
+    '#ff5722',
+  ] as readonly string[],
+} as const;
+
+export type ColorTokens = typeof colorTokens;

--- a/src/theme/utils.ts
+++ b/src/theme/utils.ts
@@ -148,6 +148,12 @@ export const themeStyles = {
   }),
 };
 
+/**
+ * Returns a hex string for a given index in the chart color palette.
+ * Import colorTokens.chart directly if you need the full array.
+ */
+export { colorTokens } from './tokens';
+
 // CSS Custom Properties for theme values
 export const cssVars = {
   // Get CSS custom property value


### PR DESCRIPTION
## Summary

- **New `src/theme/tokens.ts`** — single source of truth for all color values, mirroring Figma variable names 1:1. The only file in the codebase permitted to contain raw hex literals. Brand colors seeded from Figma: Primary Blue `#2680D9`, Light Blue `#E9F2FB`, Dark Blue `#0059B2`, Secondary `#E51A5D`.
- **`themeConfig.ts` rewritten** — imports `colorTokens` from `tokens.ts`; zero raw hex values. Standard MUI palette slots (`primary`, `secondary`, `background`, `text`, `divider`, `success`, `error`, `warning`, `info`) used throughout.
- **`COLORS` constant removed** from `appConstants.ts` — the old `COLORS.PRIMARY` (`#464b8a`) conflicted with the actual theme primary; all 8 component usages replaced with `theme.palette.*` or MUI sx shorthands.
- **ESLint guard** — `no-restricted-syntax` rule (warn level) bans raw hex literals in all `.ts`/`.tsx` files except `tokens.ts`. Prevents Figma drift in future code. Will be promoted to `error` once the ~672 pre-existing violations are cleaned up component-by-component.
- **`colorTokens` exported** from theme index/utils for components that need direct palette access (chart colors, avatar backgrounds).

## Components updated

| File | Change |
|------|--------|
| `LeaveSummaryChart.tsx` | Hardcoded `['#8884d8', '#82ca9d', '#ffc658']` → `colorTokens.chart` |
| `TeamList.tsx` | 10-element inline color array in `generateAvatarColor()` → `colorTokens.avatar` |
| `ConfirmPassword.tsx` | `COLORS.PRIMARY` → `'primary.main'` |
| `PolicyForm.tsx` | `COLORS.PRIMARY` → `'primary.main'` |
| `PolicyList.tsx` | `COLORS.PRIMARY` → `'primary.main'` |
| `HolidayList.tsx` | `darkMode ? COLORS.DARK_TEXT : COLORS.LIGHT_TEXT` → `'text.primary'` |
| `UserList.tsx` | Same pattern → `'text.primary'` |
| `Error404.tsx` | `COLORS.ACCENT` → `'warning.main'`, `COLORS.PRIMARY` → `'primary.main'` |

## Future phases (not in this PR)

- **Phase 2**: Replace ~100 `darkMode ? '#x' : '#y'` ternaries in components with `theme.palette.*`
- **Phase 3**: Fix remaining ~672 hex literal warnings in component files
- **Phase 4**: Update CSS files to use `--app-*` custom properties

## Test plan

- [ ] Light and dark mode still render correctly (primary blue, secondary pink visible)
- [ ] Charts display with brand colors (`LeaveSummaryChart`, dashboard charts)
- [ ] Avatar color generation works in `TeamList`
- [ ] `npm run lint` passes (0 errors)
- [ ] `npm run typecheck` passes (0 errors)
- [ ] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)